### PR TITLE
Actualización de fechas para PyDay 2025

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -9,32 +9,12 @@ import SponsorList from "./sponsors/components/SponsorList";
 import featuredTalks from "@/data/featuredTalks";
 import { FeatureGuard } from "@/components/FeatureManagement/FeatureGuard";
 import EmptyState from "@/components/EmptyState";
-
-// TODO: Datos de ejemplo - Estos deberían venir de una base de datos o CMS
-const cities = [
-  {
-    name: "Copiapó",
-    date: "20 de Junio, 2025",
-    slug: "copiapo",
-    mapCoords: { x: 50, y: 90 },
-  },
-  {
-    name: "Valparaíso",
-    date: "13 de Junio, 2025",
-    slug: "valparaiso",
-    mapCoords: { x: 52, y: 180 },
-  },
-  {
-    name: "Santiago",
-    date: "6 de Junio, 2025",
-    slug: "santiago",
-    mapCoords: { x: 58, y: 200 },
-  },
-];
+import cityData from "@/data/cities";
 
 export default function Home() {
-  //FIXME: Fecha del primer evento de PyDay 2025
-  const firstEventDate = "2025-06-06T09:00:00";
+  // Fecha y hora del próximo evento confirmado de PyDay 2025
+  const firstEventDate = "2025-06-06T14:00:00";
+  const citiesArray = Object.values(cityData);
 
   return (
     <>
@@ -62,7 +42,7 @@ export default function Home() {
       {/* Ciudades / Mapa Section */}
       <section id="ciudades" className="container-py mt-8">
         <h2 className="section-title">Sedes PyDay 2025</h2>
-        <ChileMap cities={cities} />
+        <ChileMap cities={citiesArray} />
       </section>
 
       {/* Agenda / Charlas Section */}

--- a/src/components/ChileMap.js
+++ b/src/components/ChileMap.js
@@ -8,7 +8,7 @@ export default function ChileMap({ cities }) {
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
       <div className="flex flex-col md:flex-row items-center gap-6">
-        {/* Contenedor del mapa con mejor contraste y accesibilidad */}
+        {/* Contenedor del mapa */}
         <div className="w-full md:w-1/2 lg:w-1/2">
           <div className="aspect-[3/6] sm:aspect-[3/5] lg:aspect-auto lg:h-[450px] w-full bg-white/5 backdrop-blur-sm rounded-lg p-4 relative shadow-lg border border-white/10">
             <svg viewBox="0 0 100 300" className="w-full h-full" aria-label="Mapa de Chile con ciudades">
@@ -59,7 +59,7 @@ export default function ChileMap({ cities }) {
           </div>
         </div>
 
-        {/* Lista de ciudades, centradas verticalmente con colores mejorados */}
+        {/* Lista de ciudades */}
         <div className="w-full md:w-1/2 lg:w-1/2 flex flex-col justify-center space-y-3">
           {cities.map((city) => (
             <Link

--- a/src/data/cities.js
+++ b/src/data/cities.js
@@ -3,7 +3,9 @@ import allTalks from "./talks";
 const cityData = {
   copiapo: {
     name: "Copiapó",
-    date: "20 de Junio, 2025",
+    date: "Fecha por confirmar.",
+    slug: "copiapo",
+    mapCoords: { x: 50, y: 90 },
     venue: "Inacap sede Copiapó",
     address: "Yumbel 650, Auditorio Edificio B, Copiapó, Chile",
     image: "/images/cities/copiapo.webp",
@@ -25,7 +27,9 @@ const cityData = {
   },
   valparaiso: {
     name: "Valparaíso",
-    date: "13 de Junio, 2025, 10:00 AM - 17:00 PM",
+    date: "13 de junio, 2025, 10:00 - 17:00.",
+    slug: "valparaiso",
+    mapCoords: { x: 52, y: 180 },
     venue: "Casa Central, Universidad Técnica Federico Santa María",
     address: "Avenida España 1680, Valparaíso, Chile",
     image: "/images/cities/valparaiso.webp",
@@ -47,7 +51,9 @@ const cityData = {
   },
   santiago: {
     name: "Santiago",
-    date: "6 de Junio, 2025",
+    date: "6 de junio, 2025, 14:00 - 19:00.",
+    slug: "santiago",
+    mapCoords: { x: 58, y: 200 },
     venue: "DUOC UC, Sede San Joaquín",
     address: "Av. Vicuña Mackenna 4917, San Joaquín, Chile",
     image: "/images/cities/santiago.webp",


### PR DESCRIPTION
Se han actualizado las fechas de los eventos de PyDay 2025 para reflejar la información más reciente. Ahora, el próximo evento confirmado es el 6 de junio de 2025 a las 14:00 horas.
Cambios realizados:
- Modificación de la constante firstEventDate con la nueva fecha y hora.
- Centralización y actualización de fechas en src\data\cities.js.

Notas adicionales:
Si hay más eventos por confirmar, estos podrán ser añadidos directamente en src\data\cities.js en futuras actualizaciones.